### PR TITLE
Wrap encoding with no_grad and strip newlines

### DIFF
--- a/from_text_to_vectors/batch-sentence-transformers.py
+++ b/from_text_to_vectors/batch-sentence-transformers.py
@@ -41,7 +41,8 @@ def batch_encode_to_vectors(input_filename, output_filename):
 
 
 def encode(documents):
-    embeddings = model.encode(documents, show_progress_bar=True)
+    with torch.no_grad():
+        embeddings = model.encode(documents, show_progress_bar=True)
     print('Vector dimension: ' + str(len(embeddings[0])))
     return embeddings
 

--- a/indexing_phase/indexer_elastic.py
+++ b/indexing_phase/indexer_elastic.py
@@ -23,6 +23,7 @@ def index_documents(documents_filename, embedding_filename_first_field, embeddin
             # For each document creates a JSON document including both text and related vector.
             for index, (document, vector_string_384, vector_string_768) in enumerate(
                     zip(documents_file, vectors_file_384, vectors_file_768)):
+                document = document.strip()
 
                 vector_384 = [float(w) for w in vector_string_384.split(",")]
                 vector_768 = [float(w) for w in vector_string_768.split(",")]

--- a/indexing_phase/indexer_elastic_with_pipeline.py
+++ b/indexing_phase/indexer_elastic_with_pipeline.py
@@ -17,6 +17,7 @@ def index_documents(documents_filename, client):
             documents = []
             # For each document creates a JSON document including text (and id).
             for index, document in enumerate(documents_file):
+                document = document.strip()
                 # Generate color value randomly (additional feature to show FILTER query behaviour).
                 color = random.choice(['red', 'green', 'white', 'black'])
                 # Create the JSON document including index name and pipeline.


### PR DESCRIPTION
Proposed efficiency improvements - avoid torch graph building (not needed for vector encoding), and strip loaded docs.