### PR TITLE
Handle missing files

### DIFF
--- a/from_text_to_vectors/batch-sentence-transformers.py
+++ b/from_text_to_vectors/batch-sentence-transformers.py
@@ -23,13 +23,12 @@ print(model.device)
 
 def batch_encode_to_vectors(input_filename, output_filename):
     """Encode text in batches and save the resulting vectors."""
-    # Open the file containing text.
-    with open(input_filename, 'r') as documents_file:
-        # Open the file in which the vectors will be saved.
-        with open(output_filename, 'w+') as out:
+    try:
+        with open(input_filename, 'r') as documents_file, \
+                open(output_filename, 'w+') as out:
             processed = 0
             # Processing 100 documents at a time.
-            for n_lines in iter(lambda: tuple(islice(documents_file, BATCH_SIZE)), ()):
+            for n_lines in iter(lambda: tuple(islice(documents_file, BATCH_SIZE)), ()): 
                 processed += 1
                 if processed % INFO_UPDATE_FACTOR == 0:
                     print("Processed {} batch of documents".format(processed))
@@ -39,6 +38,9 @@ def batch_encode_to_vectors(input_filename, output_filename):
                 for v in vectors:
                     out.write(','.join([str(i) for i in v]))
                     out.write('\n')
+    except FileNotFoundError as exc:
+        print(f"Error: file '{exc.filename}' not found.")
+        sys.exit(1)
 
 
 def encode(documents):

--- a/from_text_to_vectors/remove_id_from_corpus.py
+++ b/from_text_to_vectors/remove_id_from_corpus.py
@@ -15,9 +15,13 @@ def main():
 
 def remove_id_from_corpus(input_filename, output_filename):
     """Write a copy of the corpus without the identifier column."""
-    df = pd.read_csv(input_filename, sep='\t', names=["id", "general_text"])
-    df.drop("id", axis=1, inplace=True)
-    df.to_csv(output_filename, sep="\t", index=False, header=False)
+    try:
+        df = pd.read_csv(input_filename, sep='\t', names=["id", "general_text"])
+        df.drop("id", axis=1, inplace=True)
+        df.to_csv(output_filename, sep="\t", index=False, header=False)
+    except FileNotFoundError as exc:
+        print(f"Error: file '{exc.filename}' not found.")
+        sys.exit(1)
 
 if __name__ == "__main__":
         main()


### PR DESCRIPTION
## Summary
- catch `FileNotFoundError` in batch encoding and corpus cleaning
- exit with a concise message when the input or output file is missing

## Testing
- `python -m py_compile from_text_to_vectors/batch-sentence-transformers.py from_text_to_vectors/remove_id_from_corpus.py`

------
https://chatgpt.com/codex/tasks/task_e_68536c616f44832e81e51cbe177d26a0