### PR TITLE
Fix main() indentation

### DIFF
--- a/from_text_to_vectors/batch-sentence-transformers.py
+++ b/from_text_to_vectors/batch-sentence-transformers.py
@@ -61,4 +61,4 @@ def main():
     print('Vectors created in {:f} seconds\n'.format(finish_time - initial_time))
 
 if __name__ == "__main__":
-        main()
+    main()

--- a/from_text_to_vectors/remove_id_from_corpus.py
+++ b/from_text_to_vectors/remove_id_from_corpus.py
@@ -20,4 +20,4 @@ def remove_id_from_corpus(input_filename, output_filename):
     df.to_csv(output_filename, sep="\t", index=False, header=False)
 
 if __name__ == "__main__":
-        main()
+    main()


### PR DESCRIPTION
## Summary
- fix indentation of main() calls in from_text_to_vectors utilities

## Testing
- `python -m py_compile from_text_to_vectors/batch-sentence-transformers.py from_text_to_vectors/remove_id_from_corpus.py nlp_models/import_model.py indexing_phase/indexer_elastic.py indexing_phase/indexer_elastic_with_pipeline.py indexing_phase/create_body_for_bulk.py`

------
https://chatgpt.com/codex/tasks/task_e_68536c5dc040832e97217fca0e7efc2d